### PR TITLE
feat: Add optional authentication support with Bearer tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,7 @@
-# .env.example - Environment variables template
-# Copy to .env for local development (but use wrangler secrets for production)
-
-# Meraki API Configuration
+# Cisco Meraki API Configuration
 MERAKI_API_KEY=your_meraki_api_key_here
 MERAKI_BASE_URL=https://api.meraki.com/api/v1
 
-# Development settings
-NODE_ENV=development
-
-# Note: For production deployment, use wrangler secrets instead:
-# wrangler secret put MERAKI_API_KEY
+# Optional Authentication Token
+AUTH_TOKEN=your_secure_auth_token_here
+EOF < /dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ coverage/
 
 # TypeScript cache
 *.tsbuildinfo
+
+# CLAUDE.md
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -191,12 +191,46 @@ Add the following to your Claude Desktop configuration file:
 
 **Replace `<your-account>` with your actual Cloudflare account subdomain.**
 
+### 🔐 Authentication (Optional)
+
+To secure your MCP server with authentication:
+
+1. **Set up AUTH_TOKEN secret**:
+```bash
+wrangler secret put AUTH_TOKEN
+# Enter your desired authentication token when prompted
+```
+
+2. **Update Claude Desktop configuration** to include the auth header:
+```json
+{
+  "mcpServers": {
+    "meraki": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://meraki-mcp-cloudflare.<your-account>.workers.dev/sse",
+        "--header", "Authorization=Bearer your-auth-token-here"
+      ]
+    }
+  }
+}
+```
+
+3. **Verify authentication** by checking the health endpoint:
+```bash
+curl https://meraki-mcp-cloudflare.<your-account>.workers.dev/health
+```
+
+The response will show `"authEnabled": true` when authentication is configured.
+
 ### 🌍 Environment Variables
 
 The server uses these environment variables:
 
 - **`MERAKI_API_KEY`** (required): Your Cisco Meraki API key
 - **`MERAKI_BASE_URL`** (optional): Base URL for Meraki API (defaults to `https://api.meraki.com/api/v1`)
+- **`AUTH_TOKEN`** (optional): Authentication token for securing the MCP server
 
 ## 💡 Usage Examples
 


### PR DESCRIPTION
## Summary
- Add optional AUTH_TOKEN environment variable for securing MCP server access
- Implement authentication middleware that validates Authorization: Bearer headers
- Update health endpoint to show authentication status (authEnabled field)
- Add comprehensive documentation for authentication setup in README and CLAUDE.md
- Support graceful degradation when no auth token is configured
- Include Claude Desktop integration examples with auth headers

## Test plan
- [x] Test authentication middleware with valid tokens (passes)
- [x] Test authentication middleware with invalid tokens (401 error)
- [x] Test authentication middleware with missing headers (401 error)
- [x] Test health endpoint shows authEnabled status correctly
- [x] Verify graceful degradation when AUTH_TOKEN not set
- [x] Documentation includes complete setup instructions
- [x] Cloudflare Workers secret configured successfully

🤖 Generated with [Claude Code](https://claude.ai/code)