### PR TITLE
feat: Update Deploy to Cloudflare button with proper repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Cisco Meraki](https://img.shields.io/badge/Cisco-Meraki-1BA0D7?style=for-the-badge&logo=cisco&logoColor=white)](https://meraki.cisco.com/)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg?style=for-the-badge)](https://www.gnu.org/licenses/gpl-3.0)
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/macharpe/meraki-mcp-cloudflare)
 
 A Model Context Protocol (MCP) server that provides AI assistants with direct access to Cisco Meraki network management capabilities. This server runs on Cloudflare Workers and enables seamless integration between AI tools like Claude Desktop and your Meraki infrastructure.
 


### PR DESCRIPTION
## Summary
- Fix Deploy to Cloudflare Workers button to properly link to this repository
- This enables one-click deployment from the README for users

## Test plan
- [x] Verify the Deploy to Cloudflare button now includes the correct repository URL parameter
- [x] Confirm button still displays properly in README
- [ ] Test one-click deployment flow (optional - requires Cloudflare account)

🤖 Generated with [Claude Code](https://claude.ai/code)