### PR TITLE
fix: Correct tools count and descriptions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ The server provides **18 comprehensive Meraki management tools**:
 - **`get_devices`** - List all devices within a network
 - **`get_device`** - Get detailed information about a specific device
 - **`get_device_statuses`** - Get device statuses for an organization
-- **`get_device_performance`** - Get performance statistics for a device
 - **`get_management_interface`** - Get management interface settings for a device
 
 #### 🌐 Network Operations
@@ -399,7 +398,7 @@ src/
 ### API Coverage
 - **Organizations**: 2 methods (list, get details)
 - **Networks**: 4 methods (list, details, traffic, events)  
-- **Devices**: 5 methods (list, details, status, performance, management)
+- **Devices**: 4 methods (list, details, status, management)
 - **Wireless**: 3 methods (radio settings, status, latency stats)
 - **Switch**: 4 methods (ports, port status, routing, static routes)
 - **Clients**: 1 method (network clients)


### PR DESCRIPTION
## Summary
- Remove non-existent `get_device_performance` tool from documentation
- Update device methods count from 5 to 4 in API coverage section  
- Ensure README accurately reflects the 18 tools actually implemented in the codebase

## Test plan
- [x] Verified README tool count matches actual implementation in `src/index.ts`
- [x] Confirmed all documented tools exist in the code
- [x] Updated API coverage statistics to be accurate

🤖 Generated with [Claude Code](https://claude.ai/code)